### PR TITLE
Make type of diff less restrictive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnyDict
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2FturboMaCk%2Fany-dict%2Fbadge&style=flat)](https://actions-badge.atrox.dev/turboMaCk/any-dict/goto)
+[![Build Status](https://github.com/turboMaCk/any-dict/actions/workflows/test.yml/badge.svg)](https://github.com/turboMaCk/any-dict/actions/workflows/test.yml)
 
 This library implements a thin wrapper around
 dictionaries from core library adding support for keys of any type.
@@ -11,4 +11,4 @@ without any Kernel (Native) code and on top of existing and well tested
 
 API mirrors the standard `Dict` (and [`Dict.Extra`](https://package.elm-lang.org/packages/elm-community/dict-extra/latest/Dict.Extra)) exactly where possible.
 
-Some parts of the documentation are stolen directly from [`elm-lang/core`](http://package.elm-lang.org/packages/elm-lang/core/latest).
+Some parts of the documentation are stolen directly from [`elm/core`](http://package.elm-lang.org/packages/elm/core/latest).

--- a/src/Dict/Any.elm
+++ b/src/Dict/Any.elm
@@ -393,7 +393,7 @@ intersect (AnyDict inner) (AnyDict { dict }) =
 
 {-| Keep a key-value pair when its key does not appear in the second dictionary.
 -}
-diff : AnyDict comparable k v -> AnyDict comparable k v -> AnyDict comparable k v
+diff : AnyDict comparable k a -> AnyDict comparable k b -> AnyDict comparable k a
 diff (AnyDict inner) (AnyDict { dict }) =
     AnyDict { inner | dict = Dict.diff inner.dict dict }
 


### PR DESCRIPTION
Type of [Dict.diff](https://package.elm-lang.org/packages/elm/core/latest/Dict#diff) in elm/core:
`diff : Dict comparable a -> Dict comparable b -> Dict comparable a`


Type of [Dict.Any.diff](https://package.elm-lang.org/packages/turboMaCk/any-dict/latest/Dict-Any#diff) in turboMaCk/any-dict:
`diff :  AnyDict comparable k v -> AnyDict comparable k v -> AnyDict comparable k v`

Which is unnecessarily restrictive (just had a use case today for more polymorphic type, but couldn't use it :smile: )